### PR TITLE
Первая реализация.

### DIFF
--- a/Haptic/Haptic.xcodeproj/project.pbxproj
+++ b/Haptic/Haptic.xcodeproj/project.pbxproj
@@ -1,0 +1,415 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3C88C29A275251050062C294 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C88C299275251050062C294 /* AppDelegate.swift */; };
+		3C88C29C275251050062C294 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C88C29B275251050062C294 /* SceneDelegate.swift */; };
+		3C88C29E275251050062C294 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C88C29D275251050062C294 /* ViewController.swift */; };
+		3C88C2A3275251060062C294 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3C88C2A2275251060062C294 /* Assets.xcassets */; };
+		3C88C2A6275251060062C294 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3C88C2A4275251060062C294 /* LaunchScreen.storyboard */; };
+		3C88C2B02752513D0062C294 /* Haptic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C88C2AF2752513D0062C294 /* Haptic.swift */; };
+		3C88C2B32752518A0062C294 /* UIDevice+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C88C2B22752518A0062C294 /* UIDevice+Model.swift */; };
+		3C88C2B6275251D30062C294 /* HapticControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C88C2B5275251D30062C294 /* HapticControl.swift */; };
+		3C88C2B8275251FA0062C294 /* HapticTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C88C2B7275251FA0062C294 /* HapticTarget.swift */; };
+		3C88C2BB2752545F0062C294 /* UIControl.Event+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C88C2BA2752545F0062C294 /* UIControl.Event+Hashable.swift */; };
+		3C88C2BD2752595D0062C294 /* HapticView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C88C2BC2752595D0062C294 /* HapticView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		3C88C296275251050062C294 /* Haptic.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Haptic.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C88C299275251050062C294 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		3C88C29B275251050062C294 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		3C88C29D275251050062C294 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		3C88C2A2275251060062C294 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3C88C2A5275251060062C294 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		3C88C2A7275251060062C294 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Example/Info.plist; sourceTree = "<group>"; };
+		3C88C2AF2752513D0062C294 /* Haptic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptic.swift; sourceTree = "<group>"; };
+		3C88C2B22752518A0062C294 /* UIDevice+Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Model.swift"; sourceTree = "<group>"; };
+		3C88C2B5275251D30062C294 /* HapticControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticControl.swift; sourceTree = "<group>"; };
+		3C88C2B7275251FA0062C294 /* HapticTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticTarget.swift; sourceTree = "<group>"; };
+		3C88C2BA2752545F0062C294 /* UIControl.Event+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl.Event+Hashable.swift"; sourceTree = "<group>"; };
+		3C88C2BC2752595D0062C294 /* HapticView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3C88C293275251050062C294 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3C88C28D275251050062C294 = {
+			isa = PBXGroup;
+			children = (
+				3C88C298275251050062C294 /* Haptic */,
+				3C88C297275251050062C294 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3C88C297275251050062C294 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3C88C296275251050062C294 /* Haptic.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3C88C298275251050062C294 /* Haptic */ = {
+			isa = PBXGroup;
+			children = (
+				3C88C2AE2752512B0062C294 /* HapticFeedback */,
+				3C88C2B92752526D0062C294 /* Example */,
+				3C88C2A7275251060062C294 /* Info.plist */,
+			);
+			path = Haptic;
+			sourceTree = "<group>";
+		};
+		3C88C2AD275251100062C294 /* Lifecycle */ = {
+			isa = PBXGroup;
+			children = (
+				3C88C299275251050062C294 /* AppDelegate.swift */,
+				3C88C29B275251050062C294 /* SceneDelegate.swift */,
+			);
+			path = Lifecycle;
+			sourceTree = "<group>";
+		};
+		3C88C2AE2752512B0062C294 /* HapticFeedback */ = {
+			isa = PBXGroup;
+			children = (
+				3C88C2AF2752513D0062C294 /* Haptic.swift */,
+				3C88C2B4275251C00062C294 /* PropertyWrappers */,
+				3C88C2B1275251770062C294 /* Extension */,
+			);
+			path = HapticFeedback;
+			sourceTree = "<group>";
+		};
+		3C88C2B1275251770062C294 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				3C88C2B22752518A0062C294 /* UIDevice+Model.swift */,
+				3C88C2BA2752545F0062C294 /* UIControl.Event+Hashable.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		3C88C2B4275251C00062C294 /* PropertyWrappers */ = {
+			isa = PBXGroup;
+			children = (
+				3C88C2B5275251D30062C294 /* HapticControl.swift */,
+				3C88C2B7275251FA0062C294 /* HapticTarget.swift */,
+				3C88C2BC2752595D0062C294 /* HapticView.swift */,
+			);
+			path = PropertyWrappers;
+			sourceTree = "<group>";
+		};
+		3C88C2B92752526D0062C294 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				3C88C2AD275251100062C294 /* Lifecycle */,
+				3C88C29D275251050062C294 /* ViewController.swift */,
+				3C88C2A2275251060062C294 /* Assets.xcassets */,
+				3C88C2A4275251060062C294 /* LaunchScreen.storyboard */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		3C88C295275251050062C294 /* Haptic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3C88C2AA275251060062C294 /* Build configuration list for PBXNativeTarget "Haptic" */;
+			buildPhases = (
+				3C88C292275251050062C294 /* Sources */,
+				3C88C293275251050062C294 /* Frameworks */,
+				3C88C294275251050062C294 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Haptic;
+			productName = Haptic;
+			productReference = 3C88C296275251050062C294 /* Haptic.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3C88C28E275251050062C294 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1310;
+				LastUpgradeCheck = 1310;
+				TargetAttributes = {
+					3C88C295275251050062C294 = {
+						CreatedOnToolsVersion = 13.1;
+					};
+				};
+			};
+			buildConfigurationList = 3C88C291275251050062C294 /* Build configuration list for PBXProject "Haptic" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 3C88C28D275251050062C294;
+			productRefGroup = 3C88C297275251050062C294 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3C88C295275251050062C294 /* Haptic */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3C88C294275251050062C294 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C88C2A6275251060062C294 /* LaunchScreen.storyboard in Resources */,
+				3C88C2A3275251060062C294 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3C88C292275251050062C294 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C88C2B6275251D30062C294 /* HapticControl.swift in Sources */,
+				3C88C2BD2752595D0062C294 /* HapticView.swift in Sources */,
+				3C88C29E275251050062C294 /* ViewController.swift in Sources */,
+				3C88C2B02752513D0062C294 /* Haptic.swift in Sources */,
+				3C88C2BB2752545F0062C294 /* UIControl.Event+Hashable.swift in Sources */,
+				3C88C29A275251050062C294 /* AppDelegate.swift in Sources */,
+				3C88C29C275251050062C294 /* SceneDelegate.swift in Sources */,
+				3C88C2B8275251FA0062C294 /* HapticTarget.swift in Sources */,
+				3C88C2B32752518A0062C294 /* UIDevice+Model.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		3C88C2A4275251060062C294 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3C88C2A5275251060062C294 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		3C88C2A8275251060062C294 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		3C88C2A9275251060062C294 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		3C88C2AB275251060062C294 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U72T7VXNG3;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Haptic/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gpb.ios.Haptic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3C88C2AC275251060062C294 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U72T7VXNG3;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Haptic/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.gpb.ios.Haptic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3C88C291275251050062C294 /* Build configuration list for PBXProject "Haptic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3C88C2A8275251060062C294 /* Debug */,
+				3C88C2A9275251060062C294 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3C88C2AA275251060062C294 /* Build configuration list for PBXNativeTarget "Haptic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3C88C2AB275251060062C294 /* Debug */,
+				3C88C2AC275251060062C294 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3C88C28E275251050062C294 /* Project object */;
+}

--- a/Haptic/Haptic.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Haptic/Haptic.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Haptic/Haptic.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Haptic/Haptic.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Haptic/Haptic/Example/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Haptic/Haptic/Example/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Haptic/Haptic/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Haptic/Haptic/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Haptic/Haptic/Example/Assets.xcassets/Contents.json
+++ b/Haptic/Haptic/Example/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Haptic/Haptic/Example/Base.lproj/LaunchScreen.storyboard
+++ b/Haptic/Haptic/Example/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Haptic/Haptic/Example/Info.plist
+++ b/Haptic/Haptic/Example/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Haptic/Haptic/Example/Lifecycle/AppDelegate.swift
+++ b/Haptic/Haptic/Example/Lifecycle/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  Haptic
+//
+//  Created by Nikita Sosyuk on 27.11.2021.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/Haptic/Haptic/Example/Lifecycle/SceneDelegate.swift
+++ b/Haptic/Haptic/Example/Lifecycle/SceneDelegate.swift
@@ -1,0 +1,54 @@
+//
+//  SceneDelegate.swift
+//  Haptic
+//
+//  Created by Nikita Sosyuk on 27.11.2021.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+
+        window = UIWindow(windowScene: windowScene)
+        let vc = ViewController()
+        window?.rootViewController = vc
+        window?.makeKeyAndVisible()
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/Haptic/Haptic/Example/ViewController.swift
+++ b/Haptic/Haptic/Example/ViewController.swift
@@ -1,0 +1,135 @@
+//
+//  ViewController.swift
+//  Haptic
+//
+//  Created by Nikita Sosyuk on 27.11.2021.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    // MARK: - Private Properties
+
+    private let pickerView = UIPickerView()
+
+    @HapticControl(haptics: [.touchUpInside: .medium])
+    private var blueButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .systemRed
+        button.layer.cornerRadius = 8
+        button.setTitle("Старая кнопка", for: .normal)
+        return button
+    }()
+
+    private var redButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .systemBlue
+        button.layer.cornerRadius = 8
+        button.setTitle("Проиграть анимацию", for: .normal)
+        return button
+    }()
+
+    @HapticView(haptics: [.tap: .error])
+    private var someView: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = 14
+        view.backgroundColor = .systemGray
+        return view
+    }()
+
+    private let haptics: [(haptic: Haptic, name: String)] = [
+        (.medium, "medium"),
+        (.warning, "warning"),
+        (.error, "error"),
+        (.heavy, "heavy"),
+        (.light, "light"),
+        (.selection, "selection"),
+        (.success, "success"),
+    ]
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addSubviews()
+        setLayout()
+        setupPicker()
+
+        view.backgroundColor = .white
+
+        // Смена кнопки, чтобы проверить, что пропадают action-ы.
+        let tempButton = blueButton
+        blueButton = redButton
+        redButton = tempButton
+
+        // Смена вибрации для view.
+        _someView.changeHaptic(.heavy, for: .tap)
+    }
+
+
+    // MARK: - Private Methods
+
+    private func setupPicker() {
+        pickerView.dataSource = self
+        pickerView.delegate = self
+    }
+
+    private func addSubviews() {
+        view.addSubview(someView)
+        view.addSubview(redButton)
+        view.addSubview(blueButton)
+        view.addSubview(pickerView)
+    }
+
+    private func setLayout() {
+        someView.translatesAutoresizingMaskIntoConstraints = false
+        redButton.translatesAutoresizingMaskIntoConstraints = false
+        pickerView.translatesAutoresizingMaskIntoConstraints = false
+        blueButton.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            blueButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            blueButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+
+            redButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            redButton.topAnchor.constraint(equalTo: blueButton.bottomAnchor, constant: 20),
+
+            someView.heightAnchor.constraint(equalToConstant: 100),
+            someView.widthAnchor.constraint(equalToConstant: 100),
+            someView.topAnchor.constraint(equalTo: redButton.bottomAnchor, constant: 20),
+            someView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+
+            pickerView.centerXAnchor.constraint(equalTo: blueButton.centerXAnchor),
+            pickerView.bottomAnchor.constraint(equalTo: blueButton.topAnchor, constant: -10),
+            pickerView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8),
+            pickerView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.3)
+        ])
+    }
+}
+
+// MARK: - UIPickerViewDataSource
+
+extension ViewController: UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        1
+    }
+
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        haptics.count
+    }
+
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        haptics[row].name
+    }
+}
+
+// MARK: - UIPickerViewDataSource
+
+extension ViewController: UIPickerViewDelegate {
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        let data = haptics[row]
+        _blueButton.changeHaptic(data.haptic, for: .touchUpInside)
+    }
+}

--- a/Haptic/Haptic/HapticFeedback/Extension/UIControl.Event+Hashable.swift
+++ b/Haptic/Haptic/HapticFeedback/Extension/UIControl.Event+Hashable.swift
@@ -1,0 +1,11 @@
+//
+//  UIControl.Event+Hashable.swift
+//  Haptic
+//
+//  Created by Nikita Sosyuk on 27.11.2021.
+//
+
+import Foundation
+import UIKit
+
+extension UIControl.Event: Hashable { }

--- a/Haptic/Haptic/HapticFeedback/Extension/UIDevice+Model.swift
+++ b/Haptic/Haptic/HapticFeedback/Extension/UIDevice+Model.swift
@@ -1,0 +1,26 @@
+//
+//  UIDevice+Model.swift
+//  Haptic
+//
+//  Created by Nikita Sosyuk on 27.11.2021.
+//
+
+import UIKit
+
+extension UIDevice {
+
+    public static var currentModelName: String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8,
+                  value != 0
+            else { return identifier }
+
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+
+        return identifier
+    }
+}

--- a/Haptic/Haptic/HapticFeedback/Haptic.swift
+++ b/Haptic/Haptic/HapticFeedback/Haptic.swift
@@ -1,0 +1,102 @@
+//
+//  Haptic.swift
+//  Haptic
+//
+//  Created by Nikita Sosyuk on 27.11.2021.
+//
+
+import AudioToolbox
+import UIKit
+
+/// Девайсы, которые не поддерживают вибрации
+private let devicesWithoutHapticEngine: Set<String> = [
+    "iPhone6,1", // iPhone 5S
+    "iPhone6,2", // iPhone 5S_China
+    "iPhone7,1", // iPhone 6 Plus
+    "iPhone7,2", // iPhone 6
+    "iPhone8,1", // iPhone 6S
+    "iPhone8,2"  // iPhone 6S Plus
+]
+
+public enum Haptic {
+    case warning
+    case error
+    case success
+    case light
+    case medium
+    case heavy
+    case selection
+
+    // MARK: - Private Properties
+
+    private static let selectionGenerator = UISelectionFeedbackGenerator()
+    private static let notificationGenerator = UINotificationFeedbackGenerator()
+    private static let lightGenerator = UIImpactFeedbackGenerator(style: .light)
+    private static let heavyGenerator = UIImpactFeedbackGenerator(style: .heavy)
+    private static let mediumGenerator = UIImpactFeedbackGenerator(style: .medium)
+
+    private static let isHapticEngineAvailable: Bool = {
+        !devicesWithoutHapticEngine.contains(UIDevice.currentModelName)
+    }()
+
+    // MARK: - Public Methods
+
+    ///  Данный метод необходимо вызвать перед воспроизведением вибрации.
+    ///  Система подготовит девайс к воспроизведению вибрации, что уменьшит задержку.
+    public func prepare() {
+        guard Haptic.isHapticEngineAvailable else { return }
+
+        switch self {
+        case .error:
+            Haptic.notificationGenerator.prepare()
+
+        case .success:
+            Haptic.notificationGenerator.prepare()
+
+        case .warning:
+            Haptic.notificationGenerator.prepare()
+
+        case .light:
+            Haptic.lightGenerator.prepare()
+
+        case .medium:
+            Haptic.mediumGenerator.prepare()
+
+        case .heavy:
+            Haptic.heavyGenerator.prepare()
+
+        case .selection:
+            Haptic.selectionGenerator.prepare()
+        }
+    }
+
+    public func generate() {
+        guard Haptic.isHapticEngineAvailable else {
+            AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
+            return
+        }
+
+        switch self {
+        case .error:
+            Haptic.notificationGenerator.notificationOccurred(.error)
+
+        case .success:
+            Haptic.notificationGenerator.notificationOccurred(.success)
+
+        case .warning:
+            Haptic.notificationGenerator.notificationOccurred(.warning)
+
+        case .light:
+            Haptic.lightGenerator.impactOccurred()
+
+        case .medium:
+            Haptic.mediumGenerator.impactOccurred()
+
+        case .heavy:
+            Haptic.heavyGenerator.impactOccurred()
+
+        case .selection:
+            Haptic.selectionGenerator.selectionChanged()
+        }
+    }
+}

--- a/Haptic/Haptic/HapticFeedback/PropertyWrappers/HapticControl.swift
+++ b/Haptic/Haptic/HapticFeedback/PropertyWrappers/HapticControl.swift
@@ -1,0 +1,98 @@
+//
+//  HapticControl.swift
+//  Haptic
+//
+//  Created by Nikita Sosyuk on 27.11.2021.
+//
+
+import UIKit
+
+@propertyWrapper
+public struct HapticControl<T: UIControl> {
+
+    // MARK: - Public Properties
+
+    public var wrappedValue: T {
+        willSet {
+            self.removeAllHaptics()
+        }
+        didSet {
+            self.addAllHaptics()
+        }
+    }
+
+    // MARK: - Private Properties
+
+    private var hapticTargets: [T.Event: HapticTarget] = [:]
+
+    // MARK: - Initializers
+
+    public init(
+        wrappedValue: T,
+        haptics: [T.Event: Haptic]
+    ) {
+        self.wrappedValue = wrappedValue
+
+        haptics.forEach { self.addHaptic($0.value, for: $0.key) }
+    }
+
+    // MARK: - Public Methods
+
+    /// Изменение вибрации для определенного event-а.
+    @discardableResult
+    public mutating func changeHaptic(_ haptic: Haptic, for event: T.Event) -> Bool {
+        guard let target = self.hapticTargets[event] else { return false }
+
+        target.setHaptic(haptic)
+        return true
+    }
+
+    /// Удаление  вибрации для определенного event-а.
+    public mutating func removeHaptic(for event: T.Event) {
+        guard let hapticTarget = hapticTargets[event] else { return }
+
+        self.wrappedValue.removeTarget(
+            hapticTarget,
+            action: #selector(hapticTarget.trigger),
+            for: event
+        )
+    }
+
+    /// Добавление  вибрации для определенного event-а.
+    public mutating func addHaptic(_ haptic: Haptic, for event: T.Event) {
+        self.removeHaptic(for: event)
+
+        let hapticTarget = HapticTarget(haptic: haptic)
+        self.hapticTargets[event] = hapticTarget
+
+        self.wrappedValue.addTarget(
+            hapticTarget,
+            action: #selector(hapticTarget.trigger),
+            for: event
+        )
+    }
+
+    // MARK: - Private Methods
+
+    private mutating func addAllHaptics() {
+        let oldTargets = self.hapticTargets
+        self.hapticTargets.removeAll()
+
+        oldTargets.forEach { event, hapticTarget in
+            self.addHaptic(
+                hapticTarget.getHaptic(),
+                for: event
+            )
+        }
+    }
+
+    private func removeAllHaptics() {
+        self.hapticTargets.forEach { event, hapticTarget in
+            self.wrappedValue.removeTarget(
+                hapticTarget,
+                action: #selector(hapticTarget.trigger),
+                for: event
+            )
+        }
+    }
+}

--- a/Haptic/Haptic/HapticFeedback/PropertyWrappers/HapticTarget.swift
+++ b/Haptic/Haptic/HapticFeedback/PropertyWrappers/HapticTarget.swift
@@ -1,0 +1,36 @@
+//
+//  HapticTarget.swift
+//  Haptic
+//
+//  Created by Nikita Sosyuk on 27.11.2021.
+//
+
+import Foundation
+
+class HapticTarget {
+
+    // MARK: - Private Properties
+
+    private var haptic: Haptic
+
+    // MARK: - Initializers
+
+    init(haptic: Haptic) {
+        self.haptic = haptic
+    }
+
+    // MARK: - Internal Methods
+
+    func getHaptic() -> Haptic {
+        self.haptic
+    }
+
+    func setHaptic(_ haptic: Haptic) {
+        self.haptic = haptic
+    }
+
+    @objc func trigger() {
+        haptic.prepare()
+        haptic.generate()
+    }
+}

--- a/Haptic/Haptic/HapticFeedback/PropertyWrappers/HapticView.swift
+++ b/Haptic/Haptic/HapticFeedback/PropertyWrappers/HapticView.swift
@@ -1,0 +1,96 @@
+//
+//  HapticView.swift
+//  Haptic
+//
+//  Created by Nikita Sosyuk on 27.11.2021.
+//
+
+import UIKit
+
+@propertyWrapper
+public struct HapticView<T: UIView>{
+
+    public enum Event: Hashable {
+        case tap
+        case longPress
+    }
+
+    // MARK: - Public Properties
+
+    public var wrappedValue: T {
+        willSet {
+            self.removeAllHaptics()
+        }
+        didSet {
+            self.addAllHaptics()
+        }
+    }
+
+    // MARK: - Private Properties
+
+    private var hapticTargets: [Event: HapticTarget] = [:]
+    private var hapticRecognizers: [Event: UIGestureRecognizer] = [:]
+
+    // MARK: - Initializers
+
+    public init(
+        wrappedValue: T,
+        haptics: [Event: Haptic]
+    ) {
+        self.wrappedValue = wrappedValue
+
+        haptics.forEach { self.addHaptic($0.value, for: $0.key) }
+    }
+
+    // MARK: - Public Methods
+
+    /// Изменение вибрации для определенного event-а.
+    @discardableResult
+    public mutating func changeHaptic(_ haptic: Haptic, for event: Event) -> Bool {
+        guard let target = self.hapticTargets[event] else { return false }
+
+        target.setHaptic(haptic)
+        return true
+    }
+
+    /// Удаление  вибрации для определенного event-а.
+    public mutating func removeHaptic(for event: Event) {
+        guard let hapticRecognizer = self.hapticRecognizers[event] else { return }
+
+        wrappedValue.removeGestureRecognizer(hapticRecognizer)
+    }
+
+    /// Добавление  вибрации для определенного event-а.
+    public mutating func addHaptic(_ haptic: Haptic, for event: Event) {
+        self.removeHaptic(for: event)
+
+        let hapticTarget = HapticTarget(haptic: haptic)
+        let gestureRecognizer: UIGestureRecognizer
+        switch event {
+        case .longPress:
+            gestureRecognizer = UILongPressGestureRecognizer(
+                target: hapticTarget,
+                action: #selector(hapticTarget.trigger)
+            )
+
+        case .tap:
+            gestureRecognizer = UITapGestureRecognizer(
+                target: hapticTarget,
+                action: #selector(hapticTarget.trigger)
+            )
+        }
+
+        self.hapticTargets[event] = hapticTarget
+        self.wrappedValue.addGestureRecognizer(gestureRecognizer)
+    }
+
+    // MARK: - Private Methods
+
+    private mutating func addAllHaptics() {
+        self.hapticRecognizers.forEach { self.wrappedValue.addGestureRecognizer($0.value) }
+    }
+
+    private func removeAllHaptics() {
+        self.hapticRecognizers.forEach { self.wrappedValue.removeGestureRecognizer($0.value) }
+    }
+}

--- a/Haptic/Haptic/Info.plist
+++ b/Haptic/Haptic/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Открыт к любым предложениям. 

> Haptic - enum, по аналогии с имеющейся реализацией в libui.

> Добавил два propertyWrapper-a, дабы обойти костыли с хранением данных в extension-ах.

> 1. **HapticControl** - инкапсулирует логику с воспроизведением вибраций у контролов, содержит мапу [event: haptic], вибрации можно удалять, заменять. При смене экземпляра контрола все вибрации переносятся. 

> 2. **HapticView** - не доделывал полностью, больше как вариант реализации - если такой вообще нужен, мы обсуждали на ретро. Схож с HapticControl - просто добавляем gestureRecognizer-ы.